### PR TITLE
Add processing for lost events, consume RetinaEbpfApi metrics map API changes

### DIFF
--- a/.github/workflows/e2e-test-event-writer.yml
+++ b/.github/workflows/e2e-test-event-writer.yml
@@ -52,9 +52,19 @@ jobs:
         run: |
           echo "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\MSBuild\Current\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
-      - name: Set standalone LLVM path
+      - name: Install LLVM 18.1.8
+        shell: pwsh
         run: |
-          echo "C:\Program Files\LLVM\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+          # Install LLVM 18.1.8 to ensure consistent version across runners
+          try {
+            choco install llvm --version=18.1.8 --allow-downgrade -y --force
+            # Add installed LLVM to PATH first so it takes precedence
+            echo "C:\Program Files\LLVM\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+            Write-Host "Successfully installed LLVM 18.1.8"
+          } catch {
+            Write-Warning "Failed to install LLVM 18.1.8 via chocolatey: $($_.Exception.Message)"
+            Write-Host "Continuing with pre-installed LLVM version"
+          }
 
       - name: Nuget Restore
         shell: cmd

--- a/.github/workflows/images.yaml
+++ b/.github/workflows/images.yaml
@@ -37,7 +37,7 @@ jobs:
 
       - name: Az CLI login
         uses: azure/login@v2
-        if: ${{ (github.event_name == 'merge_group') || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/dev/v0.0.33-windows' && github.repository == 'microsoft/retina') }}
+        # if: ${{ (github.event_name == 'merge_group') || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/dev/v0.0.33-windows' && github.repository == 'microsoft/retina') }}
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
@@ -62,7 +62,8 @@ jobs:
               PLATFORM=${{ matrix.platform }}/${{ matrix.arch }}
           fi
         env:
-          SHOULD_PUSH_IMAGE: ${{ (github.event_name == 'merge_group') || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/dev/v0.0.33-windows' && github.repository == 'microsoft/retina') }}
+          # SHOULD_PUSH_IMAGE: ${{ (github.event_name == 'merge_group') || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/dev/v0.0.33-windows' && github.repository == 'microsoft/retina') }}
+          SHOULD_PUSH_IMAGE: true
 
   retina-win-images:
     name: Build Agent Windows Images
@@ -88,7 +89,7 @@ jobs:
 
       - name: Az CLI login
         uses: azure/login@v2
-        if: ${{ (github.event_name == 'merge_group') || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/dev/v0.0.33-windows' && github.repository == 'microsoft/retina') }}
+        # if: ${{ (github.event_name == 'merge_group') || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/dev/v0.0.33-windows' && github.repository == 'microsoft/retina') }}
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
@@ -115,7 +116,8 @@ jobs:
               WINDOWS_YEARS=${{ matrix.year }} 
           fi
         env:
-          SHOULD_PUSH_IMAGE: ${{ (github.event_name == 'merge_group') || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/dev/v0.0.33-windows' && github.repository == 'microsoft/retina') }}
+          # SHOULD_PUSH_IMAGE: ${{ (github.event_name == 'merge_group') || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/dev/v0.0.33-windows' && github.repository == 'microsoft/retina') }}
+          SHOULD_PUSH_IMAGE: true
 
   operator-images:
     name: Build Operator Images
@@ -140,7 +142,7 @@ jobs:
 
       - name: Az CLI login
         uses: azure/login@v2
-        if: ${{ (github.event_name == 'merge_group') || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/dev/v0.0.33-windows' && github.repository == 'microsoft/retina') }}
+        # if: ${{ (github.event_name == 'merge_group') || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/dev/v0.0.33-windows' && github.repository == 'microsoft/retina') }}
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
@@ -165,7 +167,8 @@ jobs:
               PLATFORM=${{ matrix.platform }}/${{ matrix.arch }}
           fi
         env:
-          SHOULD_PUSH_IMAGE: ${{ (github.event_name == 'merge_group') || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/dev/v0.0.33-windows' && github.repository == 'microsoft/retina') }}
+          # SHOULD_PUSH_IMAGE: ${{ (github.event_name == 'merge_group') || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/dev/v0.0.33-windows' && github.repository == 'microsoft/retina') }}
+          SHOULD_PUSH_IMAGE: true
 
   retina-shell-images:
     name: Build Retina Shell Images
@@ -190,7 +193,7 @@ jobs:
 
       - name: Az CLI login
         uses: azure/login@v2
-        if: ${{ (github.event_name == 'merge_group') || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/dev/v0.0.33-windows' && github.repository == 'microsoft/retina') }}
+        # if: ${{ (github.event_name == 'merge_group') || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/dev/v0.0.33-windows' && github.repository == 'microsoft/retina') }}
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
@@ -214,7 +217,8 @@ jobs:
               PLATFORM=${{ matrix.platform }}/${{ matrix.arch }}
           fi
         env:
-          SHOULD_PUSH_IMAGE: ${{ (github.event_name == 'merge_group') || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/dev/v0.0.33-windows' && github.repository == 'microsoft/retina') }}
+          # SHOULD_PUSH_IMAGE: ${{ (github.event_name == 'merge_group') || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/dev/v0.0.33-windows' && github.repository == 'microsoft/retina') }}
+          SHOULD_PUSH_IMAGE: true
 
   kubectl-retina-images:
     name: Build Kubectl Retina Images
@@ -239,7 +243,7 @@ jobs:
 
       - name: Az CLI login
         uses: azure/login@v2
-        if: ${{ (github.event_name == 'merge_group') || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/dev/v0.0.33-windows' && github.repository == 'microsoft/retina') }}
+        # if: ${{ (github.event_name == 'merge_group') || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/dev/v0.0.33-windows' && github.repository == 'microsoft/retina') }}
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
@@ -263,11 +267,12 @@ jobs:
               PLATFORM=${{ matrix.platform }}/${{ matrix.arch }}
           fi
         env:
-          SHOULD_PUSH_IMAGE: ${{ (github.event_name == 'merge_group') || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/dev/v0.0.33-windows' && github.repository == 'microsoft/retina') }}
+          # SHOULD_PUSH_IMAGE: ${{ (github.event_name == 'merge_group') || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/dev/v0.0.33-windows' && github.repository == 'microsoft/retina') }}
+          SHOULD_PUSH_IMAGE: true
 
   manifests:
     name: Generate Manifests
-    if: ${{ (github.event_name == 'merge_group') || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/dev/v0.0.33-windows' && github.repository == 'microsoft/retina') }}
+    # if: ${{ (github.event_name == 'merge_group') || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/dev/v0.0.33-windows' && github.repository == 'microsoft/retina') }}
     runs-on: ubuntu-latest
     needs:
       [
@@ -306,7 +311,7 @@ jobs:
 
   e2e:
     name: Run E2E Tests
-    if: ${{ (github.event_name == 'merge_group') || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/dev/v0.0.33-windows' && github.repository == 'microsoft/retina') }}
+    # if: ${{ (github.event_name == 'merge_group') || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/dev/v0.0.33-windows' && github.repository == 'microsoft/retina') }}
     needs: [manifests]
     runs-on: ubuntu-latest
 
@@ -322,7 +327,7 @@ jobs:
 
       - name: Az CLI login
         uses: azure/login@v2
-        if: ${{ (github.event_name == 'merge_group') || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/dev/v0.0.33-windows' && github.repository == 'microsoft/retina') }}
+        # if: ${{ (github.event_name == 'merge_group') || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/dev/v0.0.33-windows' && github.repository == 'microsoft/retina') }}
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}

--- a/.github/workflows/images.yaml
+++ b/.github/workflows/images.yaml
@@ -37,7 +37,7 @@ jobs:
 
       - name: Az CLI login
         uses: azure/login@v2
-        # if: ${{ (github.event_name == 'merge_group') || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/dev/v0.0.33-windows' && github.repository == 'microsoft/retina') }}
+        if: ${{ (github.event_name == 'merge_group') || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/dev/v0.0.33-windows' && github.repository == 'microsoft/retina') }}
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
@@ -62,8 +62,7 @@ jobs:
               PLATFORM=${{ matrix.platform }}/${{ matrix.arch }}
           fi
         env:
-          # SHOULD_PUSH_IMAGE: ${{ (github.event_name == 'merge_group') || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/dev/v0.0.33-windows' && github.repository == 'microsoft/retina') }}
-          SHOULD_PUSH_IMAGE: true
+          SHOULD_PUSH_IMAGE: ${{ (github.event_name == 'merge_group') || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/dev/v0.0.33-windows' && github.repository == 'microsoft/retina') }}
 
   retina-win-images:
     name: Build Agent Windows Images
@@ -89,7 +88,7 @@ jobs:
 
       - name: Az CLI login
         uses: azure/login@v2
-        # if: ${{ (github.event_name == 'merge_group') || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/dev/v0.0.33-windows' && github.repository == 'microsoft/retina') }}
+        if: ${{ (github.event_name == 'merge_group') || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/dev/v0.0.33-windows' && github.repository == 'microsoft/retina') }}
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
@@ -116,8 +115,7 @@ jobs:
               WINDOWS_YEARS=${{ matrix.year }} 
           fi
         env:
-          # SHOULD_PUSH_IMAGE: ${{ (github.event_name == 'merge_group') || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/dev/v0.0.33-windows' && github.repository == 'microsoft/retina') }}
-          SHOULD_PUSH_IMAGE: true
+          SHOULD_PUSH_IMAGE: ${{ (github.event_name == 'merge_group') || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/dev/v0.0.33-windows' && github.repository == 'microsoft/retina') }}
 
   operator-images:
     name: Build Operator Images
@@ -142,7 +140,7 @@ jobs:
 
       - name: Az CLI login
         uses: azure/login@v2
-        # if: ${{ (github.event_name == 'merge_group') || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/dev/v0.0.33-windows' && github.repository == 'microsoft/retina') }}
+        if: ${{ (github.event_name == 'merge_group') || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/dev/v0.0.33-windows' && github.repository == 'microsoft/retina') }}
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
@@ -167,8 +165,7 @@ jobs:
               PLATFORM=${{ matrix.platform }}/${{ matrix.arch }}
           fi
         env:
-          # SHOULD_PUSH_IMAGE: ${{ (github.event_name == 'merge_group') || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/dev/v0.0.33-windows' && github.repository == 'microsoft/retina') }}
-          SHOULD_PUSH_IMAGE: true
+          SHOULD_PUSH_IMAGE: ${{ (github.event_name == 'merge_group') || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/dev/v0.0.33-windows' && github.repository == 'microsoft/retina') }}
 
   retina-shell-images:
     name: Build Retina Shell Images
@@ -193,7 +190,7 @@ jobs:
 
       - name: Az CLI login
         uses: azure/login@v2
-        # if: ${{ (github.event_name == 'merge_group') || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/dev/v0.0.33-windows' && github.repository == 'microsoft/retina') }}
+        if: ${{ (github.event_name == 'merge_group') || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/dev/v0.0.33-windows' && github.repository == 'microsoft/retina') }}
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
@@ -217,8 +214,7 @@ jobs:
               PLATFORM=${{ matrix.platform }}/${{ matrix.arch }}
           fi
         env:
-          # SHOULD_PUSH_IMAGE: ${{ (github.event_name == 'merge_group') || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/dev/v0.0.33-windows' && github.repository == 'microsoft/retina') }}
-          SHOULD_PUSH_IMAGE: true
+          SHOULD_PUSH_IMAGE: ${{ (github.event_name == 'merge_group') || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/dev/v0.0.33-windows' && github.repository == 'microsoft/retina') }}
 
   kubectl-retina-images:
     name: Build Kubectl Retina Images
@@ -243,7 +239,7 @@ jobs:
 
       - name: Az CLI login
         uses: azure/login@v2
-        # if: ${{ (github.event_name == 'merge_group') || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/dev/v0.0.33-windows' && github.repository == 'microsoft/retina') }}
+        if: ${{ (github.event_name == 'merge_group') || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/dev/v0.0.33-windows' && github.repository == 'microsoft/retina') }}
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
@@ -267,12 +263,11 @@ jobs:
               PLATFORM=${{ matrix.platform }}/${{ matrix.arch }}
           fi
         env:
-          # SHOULD_PUSH_IMAGE: ${{ (github.event_name == 'merge_group') || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/dev/v0.0.33-windows' && github.repository == 'microsoft/retina') }}
-          SHOULD_PUSH_IMAGE: true
+          SHOULD_PUSH_IMAGE: ${{ (github.event_name == 'merge_group') || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/dev/v0.0.33-windows' && github.repository == 'microsoft/retina') }}
 
   manifests:
     name: Generate Manifests
-    # if: ${{ (github.event_name == 'merge_group') || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/dev/v0.0.33-windows' && github.repository == 'microsoft/retina') }}
+    if: ${{ (github.event_name == 'merge_group') || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/dev/v0.0.33-windows' && github.repository == 'microsoft/retina') }}
     runs-on: ubuntu-latest
     needs:
       [
@@ -311,7 +306,7 @@ jobs:
 
   e2e:
     name: Run E2E Tests
-    # if: ${{ (github.event_name == 'merge_group') || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/dev/v0.0.33-windows' && github.repository == 'microsoft/retina') }}
+    if: ${{ (github.event_name == 'merge_group') || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/dev/v0.0.33-windows' && github.repository == 'microsoft/retina') }}
     needs: [manifests]
     runs-on: ubuntu-latest
 
@@ -327,7 +322,7 @@ jobs:
 
       - name: Az CLI login
         uses: azure/login@v2
-        # if: ${{ (github.event_name == 'merge_group') || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/dev/v0.0.33-windows' && github.repository == 'microsoft/retina') }}
+        if: ${{ (github.event_name == 'merge_group') || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/dev/v0.0.33-windows' && github.repository == 'microsoft/retina') }}
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}

--- a/.github/workflows/images.yaml
+++ b/.github/workflows/images.yaml
@@ -62,8 +62,8 @@ jobs:
               PLATFORM=${{ matrix.platform }}/${{ matrix.arch }}
           fi
         env:
-          SHOULD_PUSH_IMAGE: ${{ (github.event_name == 'merge_group') || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/dev/v0.0.33-windows' && github.repository == 'microsoft/retina') }}
-          # SHOULD_PUSH_IMAGE: true
+          # SHOULD_PUSH_IMAGE: ${{ (github.event_name == 'merge_group') || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/dev/v0.0.33-windows' && github.repository == 'microsoft/retina') }}
+          SHOULD_PUSH_IMAGE: true
 
   retina-win-images:
     name: Build Agent Windows Images
@@ -116,8 +116,8 @@ jobs:
               WINDOWS_YEARS=${{ matrix.year }} 
           fi
         env:
-          SHOULD_PUSH_IMAGE: ${{ (github.event_name == 'merge_group') || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/dev/v0.0.33-windows' && github.repository == 'microsoft/retina') }}
-          # SHOULD_PUSH_IMAGE: true
+          # SHOULD_PUSH_IMAGE: ${{ (github.event_name == 'merge_group') || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/dev/v0.0.33-windows' && github.repository == 'microsoft/retina') }}
+          SHOULD_PUSH_IMAGE: true
 
   operator-images:
     name: Build Operator Images
@@ -167,8 +167,8 @@ jobs:
               PLATFORM=${{ matrix.platform }}/${{ matrix.arch }}
           fi
         env:
-          SHOULD_PUSH_IMAGE: ${{ (github.event_name == 'merge_group') || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/dev/v0.0.33-windows' && github.repository == 'microsoft/retina') }}
-          # SHOULD_PUSH_IMAGE: true
+          # SHOULD_PUSH_IMAGE: ${{ (github.event_name == 'merge_group') || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/dev/v0.0.33-windows' && github.repository == 'microsoft/retina') }}
+          SHOULD_PUSH_IMAGE: true
 
   retina-shell-images:
     name: Build Retina Shell Images
@@ -217,8 +217,8 @@ jobs:
               PLATFORM=${{ matrix.platform }}/${{ matrix.arch }}
           fi
         env:
-          SHOULD_PUSH_IMAGE: ${{ (github.event_name == 'merge_group') || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/dev/v0.0.33-windows' && github.repository == 'microsoft/retina') }}
-          # SHOULD_PUSH_IMAGE: true
+          # SHOULD_PUSH_IMAGE: ${{ (github.event_name == 'merge_group') || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/dev/v0.0.33-windows' && github.repository == 'microsoft/retina') }}
+          SHOULD_PUSH_IMAGE: true
 
   kubectl-retina-images:
     name: Build Kubectl Retina Images
@@ -267,8 +267,8 @@ jobs:
               PLATFORM=${{ matrix.platform }}/${{ matrix.arch }}
           fi
         env:
-          SHOULD_PUSH_IMAGE: ${{ (github.event_name == 'merge_group') || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/dev/v0.0.33-windows' && github.repository == 'microsoft/retina') }}
-          # SHOULD_PUSH_IMAGE: true
+          # SHOULD_PUSH_IMAGE: ${{ (github.event_name == 'merge_group') || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/dev/v0.0.33-windows' && github.repository == 'microsoft/retina') }}
+          SHOULD_PUSH_IMAGE: true
 
   manifests:
     name: Generate Manifests

--- a/.github/workflows/images.yaml
+++ b/.github/workflows/images.yaml
@@ -62,8 +62,8 @@ jobs:
               PLATFORM=${{ matrix.platform }}/${{ matrix.arch }}
           fi
         env:
-          # SHOULD_PUSH_IMAGE: ${{ (github.event_name == 'merge_group') || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/dev/v0.0.33-windows' && github.repository == 'microsoft/retina') }}
-          SHOULD_PUSH_IMAGE: true
+          SHOULD_PUSH_IMAGE: ${{ (github.event_name == 'merge_group') || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/dev/v0.0.33-windows' && github.repository == 'microsoft/retina') }}
+          # SHOULD_PUSH_IMAGE: true
 
   retina-win-images:
     name: Build Agent Windows Images
@@ -116,8 +116,8 @@ jobs:
               WINDOWS_YEARS=${{ matrix.year }} 
           fi
         env:
-          # SHOULD_PUSH_IMAGE: ${{ (github.event_name == 'merge_group') || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/dev/v0.0.33-windows' && github.repository == 'microsoft/retina') }}
-          SHOULD_PUSH_IMAGE: true
+          SHOULD_PUSH_IMAGE: ${{ (github.event_name == 'merge_group') || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/dev/v0.0.33-windows' && github.repository == 'microsoft/retina') }}
+          # SHOULD_PUSH_IMAGE: true
 
   operator-images:
     name: Build Operator Images
@@ -167,8 +167,8 @@ jobs:
               PLATFORM=${{ matrix.platform }}/${{ matrix.arch }}
           fi
         env:
-          # SHOULD_PUSH_IMAGE: ${{ (github.event_name == 'merge_group') || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/dev/v0.0.33-windows' && github.repository == 'microsoft/retina') }}
-          SHOULD_PUSH_IMAGE: true
+          SHOULD_PUSH_IMAGE: ${{ (github.event_name == 'merge_group') || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/dev/v0.0.33-windows' && github.repository == 'microsoft/retina') }}
+          # SHOULD_PUSH_IMAGE: true
 
   retina-shell-images:
     name: Build Retina Shell Images
@@ -217,8 +217,8 @@ jobs:
               PLATFORM=${{ matrix.platform }}/${{ matrix.arch }}
           fi
         env:
-          # SHOULD_PUSH_IMAGE: ${{ (github.event_name == 'merge_group') || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/dev/v0.0.33-windows' && github.repository == 'microsoft/retina') }}
-          SHOULD_PUSH_IMAGE: true
+          SHOULD_PUSH_IMAGE: ${{ (github.event_name == 'merge_group') || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/dev/v0.0.33-windows' && github.repository == 'microsoft/retina') }}
+          # SHOULD_PUSH_IMAGE: true
 
   kubectl-retina-images:
     name: Build Kubectl Retina Images
@@ -267,8 +267,8 @@ jobs:
               PLATFORM=${{ matrix.platform }}/${{ matrix.arch }}
           fi
         env:
-          # SHOULD_PUSH_IMAGE: ${{ (github.event_name == 'merge_group') || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/dev/v0.0.33-windows' && github.repository == 'microsoft/retina') }}
-          SHOULD_PUSH_IMAGE: true
+          SHOULD_PUSH_IMAGE: ${{ (github.event_name == 'merge_group') || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/dev/v0.0.33-windows' && github.repository == 'microsoft/retina') }}
+          # SHOULD_PUSH_IMAGE: true
 
   manifests:
     name: Generate Manifests

--- a/controller/Dockerfile
+++ b/controller/Dockerfile
@@ -48,7 +48,7 @@ RUN if [ "$GOOS" = "linux" ] ; then \
 FROM golang AS eBPFRetinaStage
 WORKDIR /tmp
 RUN tdnf install -y unzip && \
-    curl -L -o eBPFRetina.zip https://www.nuget.org/api/v2/package/Microsoft.Wcn.Observability.eBPF.Retina.x64/0.1.0-prerelease.9 && \
+    curl -L -o eBPFRetina.zip https://www.nuget.org/api/v2/package/Microsoft.Wcn.Observability.eBPF.Retina.x64/0.1.0-prerelease.11 && \
     unzip -d eBPFRetina eBPFRetina.zip || exit 0 && \
     if [ ! -d "eBPFRetina" ]; then echo "eBPFRetina directory not found after unzip!" && exit 1; fi
 

--- a/controller/Dockerfile.windows-native
+++ b/controller/Dockerfile.windows-native
@@ -27,7 +27,7 @@ FROM --platform=$BUILDPLATFORM mcr.microsoft.com/oss/go/microsoft/golang@sha256:
 FROM golang AS eBPFRetinaStage
 WORKDIR /tmp
 RUN tdnf install -y unzip && \
-    curl -L -o eBPFRetina.zip https://www.nuget.org/api/v2/package/Microsoft.Wcn.Observability.eBPF.Retina.x64/0.1.0-prerelease.9 && \
+    curl -L -o eBPFRetina.zip https://www.nuget.org/api/v2/package/Microsoft.Wcn.Observability.eBPF.Retina.x64/0.1.0-prerelease.11 && \
     unzip -d eBPFRetina eBPFRetina.zip || exit 0 && \
     if [ ! -d "eBPFRetina" ]; then echo "eBPFRetina directory not found after unzip!" && exit 1; fi
 

--- a/pkg/plugin/ebpfwindows/ebpf_windows.go
+++ b/pkg/plugin/ebpfwindows/ebpf_windows.go
@@ -102,7 +102,7 @@ func (p *Plugin) Start(ctx context.Context) error {
 }
 
 // metricsMapIterateCallback is the callback function that is called for each key-value pair in the metrics map.
-func (p *Plugin) metricsMapIterateCallback(key *MetricsKey, value *MetricsValues) {
+func (p *Plugin) metricsMapIterateCallback(key *MetricsKey, value *MetricsValue) {
 	if key == nil {
 		p.l.Error("MetricsMapIterateCallback key is nil")
 		return
@@ -114,20 +114,20 @@ func (p *Plugin) metricsMapIterateCallback(key *MetricsKey, value *MetricsValues
 	if key.IsDrop() {
 		p.l.Debug("MetricsMapIterateCallback Drop", zap.String("key", key.String()))
 		if key.IsEgress() {
-			metrics.DropBytesGauge.WithLabelValues(key.DropForwardReason(), egressLabel).Set(float64(value.BytesSum()))
-			metrics.DropPacketsGauge.WithLabelValues(key.DropForwardReason(), egressLabel).Set(float64(value.Sum()))
+			metrics.DropBytesGauge.WithLabelValues(key.DropForwardReason(), egressLabel).Set(float64(value.Bytes))
+			metrics.DropPacketsGauge.WithLabelValues(key.DropForwardReason(), egressLabel).Set(float64(value.Count))
 		} else if key.IsIngress() {
-			metrics.DropBytesGauge.WithLabelValues(key.DropForwardReason(), ingressLabel).Set(float64(value.BytesSum()))
-			metrics.DropPacketsGauge.WithLabelValues(key.DropForwardReason(), ingressLabel).Set(float64(value.Sum()))
+			metrics.DropBytesGauge.WithLabelValues(key.DropForwardReason(), ingressLabel).Set(float64(value.Bytes))
+			metrics.DropPacketsGauge.WithLabelValues(key.DropForwardReason(), ingressLabel).Set(float64(value.Count))
 		}
 	} else {
 		p.l.Debug("MetricsMapIterateCallback Forward", zap.String("key", key.String()))
 		if key.IsEgress() {
-			metrics.ForwardPacketsGauge.WithLabelValues(egressLabel).Set(float64(value.Sum()))
-			metrics.ForwardBytesGauge.WithLabelValues(egressLabel).Set(float64(value.BytesSum()))
+			metrics.ForwardPacketsGauge.WithLabelValues(egressLabel).Set(float64(value.Count))
+			metrics.ForwardBytesGauge.WithLabelValues(egressLabel).Set(float64(value.Bytes))
 		} else if key.IsIngress() {
-			metrics.ForwardPacketsGauge.WithLabelValues(ingressLabel).Set(float64(value.Sum()))
-			metrics.ForwardBytesGauge.WithLabelValues(ingressLabel).Set(float64(value.BytesSum()))
+			metrics.ForwardPacketsGauge.WithLabelValues(ingressLabel).Set(float64(value.Count))
+			metrics.ForwardBytesGauge.WithLabelValues(ingressLabel).Set(float64(value.Bytes))
 		}
 	}
 }

--- a/pkg/plugin/ebpfwindows/ebpf_windows_test.go
+++ b/pkg/plugin/ebpfwindows/ebpf_windows_test.go
@@ -371,8 +371,9 @@ func TestMetricsMapIterateCallback_DropEgress(t *testing.T) {
 		l: log.Logger().Named("test-ebpf"),
 	}
 	keyDrop := &MetricsKey{
+		Version:        1,
 		Reason:         2,
-		Dir:            dirEgress,
+		Direction:      dirEgress,
 		ExtendedReason: 0, // Extended reason is not used in this test
 	}
 	val := &MetricsValue{Count: 1, Bytes: pktSizeBytes}
@@ -399,8 +400,9 @@ func TestMetricsMapIterateCallback_DropIngress(t *testing.T) {
 		l: log.Logger().Named("test-ebpf"),
 	}
 	keyDrop := &MetricsKey{
+		Version:        1,
 		Reason:         2,
-		Dir:            dirIngress,
+		Direction:      dirIngress,
 		ExtendedReason: 0, // Extended reason is not used in this test
 	}
 	val := &MetricsValue{Count: 1, Bytes: pktSizeBytes}
@@ -427,8 +429,9 @@ func TestMetricsMapIterateCallback_ForwardEgress(t *testing.T) {
 		l: log.Logger().Named("test-ebpf"),
 	}
 	keyFwd := &MetricsKey{
+		Version:        1,
 		Reason:         0,
-		Dir:            dirEgress,
+		Direction:      dirEgress,
 		ExtendedReason: 0, // Extended reason is not used in this test
 	}
 	val := &MetricsValue{Count: 1, Bytes: pktSizeBytes}
@@ -455,8 +458,9 @@ func TestMetricsMapIterateCallback_ForwardIngress(t *testing.T) {
 		l: log.Logger().Named("test-ebpf"),
 	}
 	keyFwd := &MetricsKey{
+		Version:        1,
 		Reason:         0,
-		Dir:            dirIngress,
+		Direction:      dirIngress,
 		ExtendedReason: 0, // Extended reason is not used in this test
 	}
 	val := &MetricsValue{Count: 1, Bytes: pktSizeBytes}

--- a/pkg/plugin/ebpfwindows/ebpf_windows_test.go
+++ b/pkg/plugin/ebpfwindows/ebpf_windows_test.go
@@ -371,11 +371,9 @@ func TestMetricsMapIterateCallback_DropEgress(t *testing.T) {
 		l: log.Logger().Named("test-ebpf"),
 	}
 	keyDrop := &MetricsKey{
-		Reason:   2,
-		Dir:      dirEgress,
-		Line:     0,
-		File:     0,
-		Reserved: [3]uint8{0, 0, 0},
+		Reason:         2,
+		Dir:            dirEgress,
+		ExtendedReason: 0, // Extended reason is not used in this test
 	}
 	val := &MetricsValues{{Count: 1, Bytes: pktSizeBytes}}
 	p.metricsMapIterateCallback(keyDrop, val)
@@ -401,11 +399,9 @@ func TestMetricsMapIterateCallback_DropIngress(t *testing.T) {
 		l: log.Logger().Named("test-ebpf"),
 	}
 	keyDrop := &MetricsKey{
-		Reason:   2,
-		Dir:      dirIngress,
-		Line:     0,
-		File:     0,
-		Reserved: [3]uint8{0, 0, 0},
+		Reason:         2,
+		Dir:            dirIngress,
+		ExtendedReason: 0, // Extended reason is not used in this test
 	}
 	val := &MetricsValues{{Count: 1, Bytes: pktSizeBytes}}
 	p.metricsMapIterateCallback(keyDrop, val)
@@ -431,11 +427,9 @@ func TestMetricsMapIterateCallback_ForwardEgress(t *testing.T) {
 		l: log.Logger().Named("test-ebpf"),
 	}
 	keyFwd := &MetricsKey{
-		Reason:   0,
-		Dir:      dirEgress,
-		Line:     0,
-		File:     0,
-		Reserved: [3]uint8{0, 0, 0},
+		Reason:         0,
+		Dir:            dirEgress,
+		ExtendedReason: 0, // Extended reason is not used in this test
 	}
 	val := &MetricsValues{{Count: 1, Bytes: pktSizeBytes}}
 	p.metricsMapIterateCallback(keyFwd, val)
@@ -461,11 +455,9 @@ func TestMetricsMapIterateCallback_ForwardIngress(t *testing.T) {
 		l: log.Logger().Named("test-ebpf"),
 	}
 	keyFwd := &MetricsKey{
-		Reason:   0,
-		Dir:      dirIngress,
-		Line:     0,
-		File:     0,
-		Reserved: [3]uint8{0, 0, 0},
+		Reason:         0,
+		Dir:            dirIngress,
+		ExtendedReason: 0, // Extended reason is not used in this test
 	}
 	val := &MetricsValues{{Count: 1, Bytes: pktSizeBytes}}
 	p.metricsMapIterateCallback(keyFwd, val)
@@ -545,36 +537,7 @@ func TestIterateWithCallback_Error_NilMetricsValue(t *testing.T) {
 	}
 
 	fakeKey := &MetricsKey{}
-	enumCallBack(unsafe.Pointer(fakeKey), nil, 0)
-	if called {
-		t.Errorf("expected callback not to be called")
-	}
-}
-
-// TestIterateWithCallback_Error_ZeroMetricsValueSize tests the behavior of the IterateWithCallback function
-// when retinaEBPFAPI invokes enumCallBack with zero value size.
-func TestIterateWithCallback_Error_ZeroMetricsValueSize(t *testing.T) {
-	// Mock the function variable to simulate a successful Windows API call
-	orig := callEnumMetricsMap
-	callEnumMetricsMap = func(_ uintptr) (uintptr, uintptr, error) {
-		return 0, 0, nil
-	}
-	defer func() { callEnumMetricsMap = orig }()
-
-	m := NewMetricsMap()
-	logger := log.Logger().Named("test-ebpf")
-
-	called := false
-	err := m.IterateWithCallback(logger, func(_ *MetricsKey, _ *MetricsValues) {
-		called = true
-	})
-	if err != nil {
-		t.Fatalf("expected no error, got %v", err)
-	}
-
-	fakeKey := &MetricsKey{}
-	fakeValues := &MetricsValues{{}}
-	enumCallBack(unsafe.Pointer(fakeKey), unsafe.Pointer(&(*fakeValues)[0]), 0)
+	enumCallBack(unsafe.Pointer(fakeKey), nil)
 	if called {
 		t.Errorf("expected callback not to be called")
 	}
@@ -602,7 +565,7 @@ func TestIterateWithCallback_Error_NilMetricsKey(t *testing.T) {
 	}
 
 	fakeValues := &MetricsValues{{}}
-	enumCallBack(unsafe.Pointer(nil), unsafe.Pointer(&(*fakeValues)[0]), len(*fakeValues))
+	enumCallBack(unsafe.Pointer(nil), unsafe.Pointer(&(*fakeValues)[0]))
 	if called {
 		t.Errorf("expected callback not to be called")
 	}
@@ -630,7 +593,7 @@ func TestIterateWithCallback_Error_NilMetricValue(t *testing.T) {
 	}
 
 	fakeKey := &MetricsKey{}
-	enumCallBack(unsafe.Pointer(fakeKey), unsafe.Pointer(nil), 0)
+	enumCallBack(unsafe.Pointer(fakeKey), unsafe.Pointer(nil))
 	if called {
 		t.Errorf("expected callback not to be called")
 	}
@@ -659,7 +622,7 @@ func TestIterateWithCallback_Success(t *testing.T) {
 
 	fakeKey := &MetricsKey{}
 	fakeValues := &MetricsValues{{}}
-	enumCallBack(unsafe.Pointer(fakeKey), unsafe.Pointer(&(*fakeValues)[0]), len(*fakeValues))
+	enumCallBack(unsafe.Pointer(fakeKey), unsafe.Pointer(&(*fakeValues)[0]))
 	if !called {
 		t.Errorf("expected callback to be called")
 	}

--- a/pkg/plugin/ebpfwindows/ebpf_windows_test.go
+++ b/pkg/plugin/ebpfwindows/ebpf_windows_test.go
@@ -375,7 +375,7 @@ func TestMetricsMapIterateCallback_DropEgress(t *testing.T) {
 		Dir:            dirEgress,
 		ExtendedReason: 0, // Extended reason is not used in this test
 	}
-	val := &MetricsValues{{Count: 1, Bytes: pktSizeBytes}}
+	val := &MetricsValue{Count: 1, Bytes: pktSizeBytes}
 	p.metricsMapIterateCallback(keyDrop, val)
 	_, err := metrics.DropBytesGauge.GetMetricWithLabelValues("Reason_InvalidPacket", "egress")
 	if err != nil {
@@ -403,7 +403,7 @@ func TestMetricsMapIterateCallback_DropIngress(t *testing.T) {
 		Dir:            dirIngress,
 		ExtendedReason: 0, // Extended reason is not used in this test
 	}
-	val := &MetricsValues{{Count: 1, Bytes: pktSizeBytes}}
+	val := &MetricsValue{Count: 1, Bytes: pktSizeBytes}
 	p.metricsMapIterateCallback(keyDrop, val)
 	_, err := metrics.DropBytesGauge.GetMetricWithLabelValues("Reason_InvalidPacket", "ingress")
 	if err != nil {
@@ -431,7 +431,7 @@ func TestMetricsMapIterateCallback_ForwardEgress(t *testing.T) {
 		Dir:            dirEgress,
 		ExtendedReason: 0, // Extended reason is not used in this test
 	}
-	val := &MetricsValues{{Count: 1, Bytes: pktSizeBytes}}
+	val := &MetricsValue{Count: 1, Bytes: pktSizeBytes}
 	p.metricsMapIterateCallback(keyFwd, val)
 	_, err := metrics.ForwardBytesGauge.GetMetricWithLabelValues("egress")
 	if err != nil {
@@ -459,7 +459,7 @@ func TestMetricsMapIterateCallback_ForwardIngress(t *testing.T) {
 		Dir:            dirIngress,
 		ExtendedReason: 0, // Extended reason is not used in this test
 	}
-	val := &MetricsValues{{Count: 1, Bytes: pktSizeBytes}}
+	val := &MetricsValue{Count: 1, Bytes: pktSizeBytes}
 	p.metricsMapIterateCallback(keyFwd, val)
 	_, err := metrics.ForwardBytesGauge.GetMetricWithLabelValues("ingress")
 	if err != nil {
@@ -489,7 +489,7 @@ func TestMetricsMapIterateCallback_NilKey(t *testing.T) {
 		},
 		l: log.Logger().Named("test-ebpf"),
 	}
-	fakeValues := &MetricsValues{{}}
+	fakeValues := &MetricsValue{}
 	p.metricsMapIterateCallback(nil, fakeValues)
 }
 
@@ -529,7 +529,7 @@ func TestIterateWithCallback_Error_NilMetricsValue(t *testing.T) {
 	logger := log.Logger().Named("test-ebpf")
 
 	called := false
-	err := m.IterateWithCallback(logger, func(_ *MetricsKey, _ *MetricsValues) {
+	err := m.IterateWithCallback(logger, func(_ *MetricsKey, _ *MetricsValue) {
 		called = true
 	})
 	if err != nil {
@@ -557,15 +557,15 @@ func TestIterateWithCallback_Error_NilMetricsKey(t *testing.T) {
 	logger := log.Logger().Named("test-ebpf")
 
 	called := false
-	err := m.IterateWithCallback(logger, func(_ *MetricsKey, _ *MetricsValues) {
+	err := m.IterateWithCallback(logger, func(_ *MetricsKey, _ *MetricsValue) {
 		called = true
 	})
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
 
-	fakeValues := &MetricsValues{{}}
-	enumCallBack(unsafe.Pointer(nil), unsafe.Pointer(&(*fakeValues)[0]))
+	fakeValues := &MetricsValue{}
+	enumCallBack(unsafe.Pointer(nil), unsafe.Pointer(fakeValues))
 	if called {
 		t.Errorf("expected callback not to be called")
 	}
@@ -585,7 +585,7 @@ func TestIterateWithCallback_Error_NilMetricValue(t *testing.T) {
 	logger := log.Logger().Named("test-ebpf")
 
 	called := false
-	err := m.IterateWithCallback(logger, func(_ *MetricsKey, _ *MetricsValues) {
+	err := m.IterateWithCallback(logger, func(_ *MetricsKey, _ *MetricsValue) {
 		called = true
 	})
 	if err != nil {
@@ -613,7 +613,7 @@ func TestIterateWithCallback_Success(t *testing.T) {
 	logger := log.Logger().Named("test-ebpf")
 
 	called := false
-	err := m.IterateWithCallback(logger, func(_ *MetricsKey, _ *MetricsValues) {
+	err := m.IterateWithCallback(logger, func(_ *MetricsKey, _ *MetricsValue) {
 		called = true
 	})
 	if err != nil {
@@ -621,8 +621,8 @@ func TestIterateWithCallback_Success(t *testing.T) {
 	}
 
 	fakeKey := &MetricsKey{}
-	fakeValues := &MetricsValues{{}}
-	enumCallBack(unsafe.Pointer(fakeKey), unsafe.Pointer(&(*fakeValues)[0]))
+	fakeValues := &MetricsValue{}
+	enumCallBack(unsafe.Pointer(fakeKey), unsafe.Pointer(fakeValues))
 	if !called {
 		t.Errorf("expected callback to be called")
 	}

--- a/pkg/plugin/ebpfwindows/metricsmap_windows.go
+++ b/pkg/plugin/ebpfwindows/metricsmap_windows.go
@@ -30,7 +30,7 @@ var direction = map[uint8]string{
 type MetricsKey struct {
 	Version        uint8
 	Reason         uint8
-	Dir            uint8
+	Direction      uint8
 	ExtendedReason uint16
 }
 
@@ -127,14 +127,16 @@ func MetricDirection(dir uint8) string {
 	return direction[dirUnknown]
 }
 
-// Direction gets the direction in human readable string format
-func (k *MetricsKey) Direction() string {
-	return MetricDirection(k.Dir)
+// DirectionString gets the direction in human readable string format
+func (k *MetricsKey) DirectionString() string {
+	// The direction field is a 2-bit field in the C struct, so mask the lower 2 bits
+	direction := k.Direction & 0x03
+	return MetricDirection(direction)
 }
 
 // String returns the key in human readable string format
 func (k *MetricsKey) String() string {
-	return fmt.Sprintf("Direction: %s, Reason: %s", k.Direction(), k.DropForwardReason())
+	return fmt.Sprintf("Direction: %s, Reason: %s", k.DirectionString(), k.DropForwardReason())
 }
 
 // DropForwardReason gets the forwarded/dropped reason in human readable string format
@@ -160,12 +162,16 @@ func (k *MetricsKey) IsDrop() bool {
 
 // IsIngress checks if the direction is ingress or not.
 func (k *MetricsKey) IsIngress() bool {
-	return k.Dir == dirIngress
+	// The direction field is a 2-bit field in the C struct, so mask the lower 2 bits
+	direction := k.Direction & 0x03
+	return direction == dirIngress
 }
 
 // IsEgress checks if the direction is egress or not.
 func (k *MetricsKey) IsEgress() bool {
-	return k.Dir == dirEgress
+	// The direction field is a 2-bit field in the C struct, so mask the lower 2 bits
+	direction := k.Direction & 0x03
+	return direction == dirEgress
 }
 
 func GetLostEventsCount() (uint64, error) {

--- a/pkg/plugin/ebpfwindows/metricsmap_windows.go
+++ b/pkg/plugin/ebpfwindows/metricsmap_windows.go
@@ -65,6 +65,7 @@ var (
 	retinaEbpfAPI = windows.NewLazyDLL("retinaebpfapi.dll")
 	// Load the RetinaEnumerateMetricsMap function
 	enumMetricsMap = retinaEbpfAPI.NewProc("RetinaEnumerateMetricsMap")
+	lostEventCount = retinaEbpfAPI.NewProc("RetinaGetLostEventsCount")
 )
 
 // ringBufferEventCallback type definition in Go
@@ -209,4 +210,12 @@ func (vs MetricsValues) BytesSum() uint64 {
 
 func (vs MetricsValues) String() string {
 	return fmt.Sprintf("Sum: %d, BytesSum: %d", vs.Sum(), vs.BytesSum())
+}
+
+func GetLostEventsCount() (uint64, error) {
+	ret, _, err := lostEventCount.Call()
+	if err != nil && err != syscall.Errno(0) {
+		return 0, fmt.Errorf("RetinaGetLostEventsCount call failed: %w", err)
+	}
+	return uint64(ret), nil
 }

--- a/pkg/plugin/ebpfwindows/metricsmap_windows.go
+++ b/pkg/plugin/ebpfwindows/metricsmap_windows.go
@@ -39,13 +39,10 @@ type MetricsValue struct {
 	Bytes uint64
 }
 
-// MetricsMapValues is a slice of MetricsMapValue
-type MetricsValues []MetricsValue
-
 // IterateCallback represents the signature of the callback function expected by
 // the IterateWithCallback method, which in turn is used to iterate all the
 // keys/values of a metrics map.
-type IterateCallback func(*MetricsKey, *MetricsValues)
+type IterateCallback func(*MetricsKey, *MetricsValue)
 
 // MetricsMap interface represents a metrics map, and can be reused to implement
 // mock maps for unit tests.
@@ -103,9 +100,9 @@ func (m metricsMap) IterateWithCallback(l *log.ZapLogger, cb IterateCallback) er
 			return 1
 		}
 
-		var metricsValues MetricsValues = unsafe.Slice((*MetricsValue)(value), 1)
+		metricsValue := (*MetricsValue)(value)
 		metricsKey := (*MetricsKey)(key)
-		cb(metricsKey, &metricsValues)
+		cb(metricsKey, metricsValue)
 		return 0
 	}
 
@@ -169,30 +166,6 @@ func (k *MetricsKey) IsIngress() bool {
 // IsEgress checks if the direction is egress or not.
 func (k *MetricsKey) IsEgress() bool {
 	return k.Dir == dirEgress
-}
-
-// Count returns the sum of all the per-CPU count values
-func (vs MetricsValues) Sum() uint64 {
-	c := uint64(0)
-	for _, v := range vs {
-		c += v.Count
-	}
-
-	return c
-}
-
-// Bytes returns the sum of all the per-CPU bytes values
-func (vs MetricsValues) BytesSum() uint64 {
-	b := uint64(0)
-	for _, v := range vs {
-		b += v.Bytes
-	}
-
-	return b
-}
-
-func (vs MetricsValues) String() string {
-	return fmt.Sprintf("Sum: %d, BytesSum: %d", vs.Sum(), vs.BytesSum())
 }
 
 func GetLostEventsCount() (uint64, error) {

--- a/pkg/plugin/ebpfwindows/metricsmap_windows.go
+++ b/pkg/plugin/ebpfwindows/metricsmap_windows.go
@@ -63,8 +63,9 @@ type metricsMap struct{}
 var (
 	// Load the retinaebpfapi.dll
 	retinaEbpfAPI = windows.NewLazyDLL("retinaebpfapi.dll")
-	// Load the RetinaEnumerateMetricsMap function
-	enumMetricsMap = retinaEbpfAPI.NewProc("RetinaEnumerateMetricsMap")
+	// Load the RetinaEnumerateMetrics function
+	enumMetricsMap = retinaEbpfAPI.NewProc("RetinaEnumerateMetrics")
+	// Load the RetinaGetLostEventsCount function
 	lostEventCount = retinaEbpfAPI.NewProc("RetinaGetLostEventsCount")
 )
 


### PR DESCRIPTION
# Description
This change adds the following:
- Updates LLVM version due to breaking changes
- Adds processing for lost events API
- Update metrics map processing due to RetinaEbpfApi changes

## Related Issue

If this pull request is related to any issue, please mention it here. Additionally, make sure that the issue is assigned to you before submitting this pull request.

## Checklist

- [ ] I have read the [contributing documentation](https://retina.sh/docs/Contributing/overview).
- [ ] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [ ] I have correctly attributed the author(s) of the code.
- [ ] I have tested the changes locally.
- [ ] I have followed the project's style guidelines.
- [ ] I have updated the documentation, if necessary.
- [ ] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

Please add any relevant screenshots or GIFs to showcase the changes made.

## Additional Notes

Add any additional notes or context about the pull request here.

---

Please refer to the [CONTRIBUTING.md](../CONTRIBUTING.md) file for more information on how to contribute to this project.
